### PR TITLE
fix a bug in LaplacianOperator.cpp

### DIFF
--- a/laplacian-mesh-editing/Classes/MeshOperator/LaplacianOperator.cpp
+++ b/laplacian-mesh-editing/Classes/MeshOperator/LaplacianOperator.cpp
@@ -128,7 +128,7 @@ LaplacianOperator::LaplacianOperator( ObjEntity* mesh,MeshDrawerImpl* drawer ):m
 
 		Eigen::Matrix<double,1,Eigen::Dynamic> TDeltaX = s*deltaInput(i,0)-h3*deltaInput(i,1)+h2*deltaInput(i,2);
 		Eigen::Matrix<double,1,Eigen::Dynamic> TDeltaY = h3*deltaInput(i,0)+s*deltaInput(i,1)-h1*deltaInput(i,2);
-		Eigen::Matrix<double,1,Eigen::Dynamic> TDeltaZ = -h2*deltaInput(i,0)-h1*deltaInput(i,1)+s*deltaInput(i,2);
+		Eigen::Matrix<double,1,Eigen::Dynamic> TDeltaZ = -h2*deltaInput(i,0)+h1*deltaInput(i,1)+s*deltaInput(i,2);
 
 		Eigen::Matrix<double,3,Eigen::Dynamic> TDelta;
 		TDelta.resize(3,TDeltaX.cols());


### PR DESCRIPTION
原论文中的公式(8)，Ti矩阵的第三行第二列应该为h1而不是-h1。